### PR TITLE
Upgrade to Netty 4.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,4 +22,4 @@ javacOptions in (Compile, doc) := Seq("-source", "1.6")
 
 libraryDependencies += "tv.cntt" % "jauter" % "1.7"
 
-libraryDependencies += "io.netty" % "netty-all" % "4.0.24.Final" % "provided"
+libraryDependencies += "io.netty" % "netty-all" % "4.1.0.Beta4" % "provided"

--- a/src/main/java/io/netty/handler/codec/http/router/AbstractHandler.java
+++ b/src/main/java/io/netty/handler/codec/http/router/AbstractHandler.java
@@ -5,6 +5,8 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderUtil;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
@@ -38,15 +40,15 @@ public abstract class AbstractHandler<T, RouteLike extends MethodRouter<T, Route
 
   @Override
   protected void channelRead0(ChannelHandlerContext ctx, HttpRequest req) throws Exception {
-    if (HttpHeaders.is100ContinueExpected(req)) {
+    if (HttpHeaderUtil.is100ContinueExpected(req)) {
       ctx.writeAndFlush(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE));
       return;
     }
 
     // Route
-    HttpMethod         method  = req.getMethod();
-    QueryStringDecoder qsd     = new QueryStringDecoder(req.getUri());
-    jauter.Routed<T>   jrouted = router.route(method, qsd.path());
+    HttpMethod method = req.method();
+    QueryStringDecoder qsd = new QueryStringDecoder(req.uri());
+    jauter.Routed<T> jrouted = router.route(method, qsd.path());
 
     if (jrouted == null) {
       respondNotFound(ctx, req);
@@ -59,14 +61,14 @@ public abstract class AbstractHandler<T, RouteLike extends MethodRouter<T, Route
 
   protected void respondNotFound(ChannelHandlerContext ctx, HttpRequest req) {
     HttpResponse res = new DefaultFullHttpResponse(
-      HttpVersion.HTTP_1_1,
-      HttpResponseStatus.NOT_FOUND,
-      Unpooled.wrappedBuffer(CONTENT_404)
+            HttpVersion.HTTP_1_1,
+            HttpResponseStatus.NOT_FOUND,
+            Unpooled.wrappedBuffer(CONTENT_404)
     );
 
     HttpHeaders headers = res.headers();
-    headers.set(HttpHeaders.Names.CONTENT_TYPE,   "text/plain");
-    headers.set(HttpHeaders.Names.CONTENT_LENGTH, CONTENT_404.length);
+    headers.set(HttpHeaderNames.CONTENT_TYPE, "text/plain");
+    HttpHeaderUtil.setContentLength(res, CONTENT_404.length);
 
     KeepAliveWrite.flush(ctx, req, res);
   }

--- a/src/main/java/io/netty/handler/codec/http/router/KeepAliveWrite.java
+++ b/src/main/java/io/netty/handler/codec/http/router/KeepAliveWrite.java
@@ -4,26 +4,28 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderUtil;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 
 /** Utilities to write. */
 public class KeepAliveWrite {
   public static ChannelFuture flush(ChannelHandlerContext ctx, HttpRequest req, HttpResponse res) {
-    if (!HttpHeaders.isKeepAlive(req)) {
+    if (!HttpHeaderUtil.isKeepAlive(req)) {
       return ctx.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE);
     } else {
-      res.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+      res.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
       return ctx.writeAndFlush(res);
     }
   }
 
   public static ChannelFuture flush(Channel ch, HttpRequest req, HttpResponse res) {
-    if (!HttpHeaders.isKeepAlive(req)) {
+    if (!HttpHeaderUtil.isKeepAlive(req)) {
       return ch.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE);
     } else {
-      res.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+      res.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
       return ch.writeAndFlush(res);
     }
   }

--- a/src/main/java/io/netty/handler/codec/http/router/MethodRouted.java
+++ b/src/main/java/io/netty/handler/codec/http/router/MethodRouted.java
@@ -120,4 +120,16 @@ public class MethodRouted<T> implements ReferenceCounted {
     if (requestAsReferenceCounted != null) requestAsReferenceCounted.retain(arg0);
     return this;
   }
+
+  @Override
+  public ReferenceCounted touch() {
+    if (requestAsReferenceCounted != null) requestAsReferenceCounted.touch();
+    return this;
+  }
+
+  @Override
+  public ReferenceCounted touch(final Object hint) {
+    if (requestAsReferenceCounted != null) requestAsReferenceCounted.touch(hint);
+    return this;
+  }
 }


### PR DESCRIPTION
Netty 4.1 changed the ReferenceCounted interface, thus breaking backwards compatibility for this component. Would it be possible to release this as a netty-router41 artifact?