### PR TITLE
replace netty StringUtil#split call with String#split

### DIFF
--- a/src/main/java/io/netty/handler/codec/http/router/MethodlessRouter.java
+++ b/src/main/java/io/netty/handler/codec/http/router/MethodlessRouter.java
@@ -15,8 +15,6 @@
  */
 package io.netty.handler.codec.http.router;
 
-import io.netty.util.internal.StringUtil;
-
 /**
  * Router that contains information about route matching orders, but doesn't
  * contain information about HTTP request methods.
@@ -109,7 +107,7 @@ final class MethodlessRouter<T> {
 
     /** @return {@code null} if no match; note: {@code queryParams} is not set in {@link RouteResult} */
     public RouteResult<T> route(String path) {
-        return route(StringUtil.split(Path.removeSlashesAtBothEnds(path), '/'));
+        return route(Path.removeSlashesAtBothEnds(path).split("/"));
     }
 
     /** @return {@code null} if no match; note: {@code queryParams} is not set in {@link RouteResult} */

--- a/src/main/java/io/netty/handler/codec/http/router/OrderlessRouter.java
+++ b/src/main/java/io/netty/handler/codec/http/router/OrderlessRouter.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http.router;
 
 import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -109,7 +108,7 @@ final class OrderlessRouter<T> {
 
     /** @return {@code null} if no match; note: {@code queryParams} is not set in {@link RouteResult} */
     public RouteResult<T> route(String path) {
-        return route(StringUtil.split(Path.removeSlashesAtBothEnds(path), '/'));
+        return route(Path.removeSlashesAtBothEnds(path).split("/"));
     }
 
     /** @return {@code null} if no match; note: {@code queryParams} is not set in {@link RouteResult} */

--- a/src/main/java/io/netty/handler/codec/http/router/Path.java
+++ b/src/main/java/io/netty/handler/codec/http/router/Path.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.http.router;
 
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.StringUtil;
 
 import java.util.Map;
 
@@ -45,7 +44,7 @@ final class Path {
             beginIndex++;
         }
         if (beginIndex == path.length()) {
-            return StringUtil.EMPTY_STRING;
+            return "";
         }
 
         int endIndex = path.length() - 1;
@@ -69,7 +68,7 @@ final class Path {
      */
     public Path(String path) {
         this.path   = removeSlashesAtBothEnds(ObjectUtil.checkNotNull(path, "path"));
-        this.tokens = StringUtil.split(this.path, '/');
+        this.tokens = this.path.split("/");
     }
 
     /** Returns the path given at the constructor, without slashes at both ends. */

--- a/src/main/java/io/netty/handler/codec/http/router/Router.java
+++ b/src/main/java/io/netty/handler/codec/http/router/Router.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http.router;
 
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.QueryStringDecoder;
-import io.netty.util.internal.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -254,7 +253,7 @@ public class Router<T> {
      */
     public RouteResult<T> route(HttpMethod method, String uri) {
         QueryStringDecoder decoder = new QueryStringDecoder(uri);
-        String[]           tokens  = StringUtil.split(Path.removeSlashesAtBothEnds(decoder.path()), '/');
+        String[]           tokens  = Path.removeSlashesAtBothEnds(decoder.path()).split("/");
 
         MethodlessRouter<T> router = routers.get(method);
         if (router == null) {
@@ -292,7 +291,7 @@ public class Router<T> {
      */
     public Set<HttpMethod> allowedMethods(String uri) {
         QueryStringDecoder decoder = new QueryStringDecoder(uri);
-        String[]           tokens  = StringUtil.split(Path.removeSlashesAtBothEnds(decoder.path()), '/');
+        String[]           tokens  = Path.removeSlashesAtBothEnds(decoder.path()).split("/");
 
         if (anyMethodRouter.anyMatched(tokens)) {
             return allAllowedMethods();


### PR DESCRIPTION
motivation:

netty StringUtil#split was removed.

https://github.com/netty/netty/commit/a80ea46b8e6d3b225547ae138a357101b0381268

changes:
- replace usage of this method in Path with String#split
